### PR TITLE
add sec-ch-ua to chromium based user-agents, add count param to api

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -12,6 +12,9 @@ def get_masq(
     ua: Union[bool, None] = True,
     rf: Union[bool, None] = False,
     hd: Union[bool, None] = False,
+    count: Union[int, None] = 1,
 ):
-    response = masq(ua, rf, hd)
+    response = [masq(ua, rf, hd)]
+    for _ in range(count - 1):
+        response.append(masq(ua, rf, hd))
     return JSONResponse(content=response)

--- a/src/masquer/utils/assets.py
+++ b/src/masquer/utils/assets.py
@@ -18,6 +18,10 @@ REFERERS = [
     "https://duckduckgo.com",
     "https://www.baidu.com",
 ]
+SEC_CH_UA = {
+    'chrome/128' : '"Chromium";v="128", "Not;A=Brand";v="24", "%c";v="128"',
+    'chrome/127' : '"Not)A;Brand";v="99", "%c";v="127", "Chromium";v="127"'
+}
 REFERER_WEIGHTS = [79.65, 11.98, 3.21, 2.47, 0.88, 0.56]
 USERAGENTS = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.3",

--- a/src/masquer/utils/response.py
+++ b/src/masquer/utils/response.py
@@ -6,7 +6,7 @@ from .assets import (
     USERAGENT_WEIGHTS,
 )
 from .select import select_data
-
+from .sec_ch import append_sec_ch
 
 def get_response(
     useragent_requested: bool, referer_requested: bool, header_requested: bool
@@ -27,7 +27,7 @@ def get_response(
     response_data = dict()
 
     if header_requested:
-        response_data = HEADER_DATA
+        response_data = dict(HEADER_DATA)
 
     if referer_requested:
         referer = select_data(REFERERS, REFERER_WEIGHTS)
@@ -36,5 +36,7 @@ def get_response(
     if useragent_requested:
         useragent = select_data(USERAGENTS, USERAGENT_WEIGHTS)
         response_data["User-Agent"] = useragent
+        if(header_requested):
+            response_data = append_sec_ch(useragent, response_data)
 
     return response_data

--- a/src/masquer/utils/sec_ch.py
+++ b/src/masquer/utils/sec_ch.py
@@ -1,0 +1,56 @@
+from .assets import (SEC_CH_UA, HEADER_DATA)
+import re
+def append_sec_ch(user_agent: str, headers: dict) -> str:
+    if(user_agent.find('Chrome') == -1):
+        return headers
+    platform = get_platform(user_agent)
+    headers['sec-ch-ua-platform'] = platform
+    headers['sec-ch-ua-mobile'] = "?1" if is_mobile(user_agent) else "?0"
+    headers['sec-ch-ua'] = find_sec_ch(get_chrome_version(user_agent)).replace('%c', get_browser(user_agent))
+    return headers
+    
+    
+
+def find_sec_ch(version: str) -> str:
+    if version in SEC_CH_UA:
+        return SEC_CH_UA[version]
+    else:
+        return "Not Found"
+    
+def get_browser(user_agent: str) -> str:
+    if('Edg' in user_agent):
+        return 'Microsoft Edge'
+    elif('OPR' in user_agent):
+        # TODO: Opera have a custom sec-ch-ua for mobile version...
+        return 'Opera'
+    else:
+        return 'Google Chrome'
+
+def get_platform(user_agent: str) -> str:
+    if('Windows' in user_agent):
+        return '"Windows"'
+    elif('Macintosh' in user_agent):
+        return '"Macintosh"'
+    elif('Android' in user_agent):
+        return '"Android"'
+    elif('iPhone' in user_agent):
+        return '"iPhone"'
+    elif('Linux' in user_agent):
+        return '"Linux"'
+    else:
+        return '"Windows"'
+    
+def is_mobile(user_agent: str) -> bool:
+    if('Android' in user_agent):
+        return True
+    elif('iPhone' in user_agent):
+        return True
+    else:
+        return False
+    
+def get_chrome_version(user_agent: str) -> str:
+    version_regex = r'Chrome\/(\d+)'
+    matches = re.search(version_regex, user_agent)
+    first_match = matches.group(0)
+    return first_match.lower()
+    


### PR DESCRIPTION
## Description
- Added "?count=10" to api params.
- Add sec-ch-x to headers if a chromium user agent was selected.
- Copy headers_data instead of referencing it to allow per-request change.
- Add SEC_CH_UA to assets.
## Testing
- All tests passed locally.
## Misc
- Will need documentation changes.
- default api response is now an array instead of an object, can possibly be changed.
- Can possibly use a user-agent parser instead of manually identifying user agent.
- Need an automated way/api to populate sec_ch_ua array in assets