### PR TITLE
Added count param in request, clone header data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The API returns JSON objects, making it compatible with any language that can ma
 Here is an example using `curl` from the command line to get a random user-agent and referer:
 
 ```console
-$ curl -X GET 'https://masquer.fly.dev/masq?ua=true&rf=true' -H 'accept: application/json'
+$ curl -X GET 'https://masquer.fly.dev/api/v1/masq?ua=true&rf=true' -H 'accept: application/json'
 {
   "Referer":"https://www.google.com",
   "User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/essteer/masquer/actions/workflows/test.yaml"><img src="https://github.com/essteer/masquer/actions/workflows/test.yaml/badge.svg"></a>
-  <a href="https://pypi.org/project/masquer/"><img src="https://img.shields.io/badge/PyPI-v1.2.2-3775A9.svg?style=flat&logo=PyPI&logoColor=white"></a>
+  <a href="https://pypi.org/project/masquer/"><img src="https://img.shields.io/pypi/v/masquer?style=flat&logo=PyPI&logoColor=white&label=PyPI&labelColor=555&color=3776AB"></a>
   <a href="https://pypi.org/project/masquer/"><img src="https://img.shields.io/badge/Python-3.9_~_3.12-3776AB.svg?style=flat&logo=Python&logoColor=white"></a>
   <a href="https://snyk.io/test/github/essteer/masquer"><img src="https://snyk.io/test/github/essteer/masquer/badge.svg?name=Snyk&style=flat&logo=Snyk"></a>
 </p>
@@ -70,12 +70,12 @@ $ curl -X GET 'https://masquer.fly.dev/masq?ua=true&rf=true' -H 'accept: applica
 Refer to the [API docs](`https://masquer.fly.dev/docs`) for other examples, or see [more details below](#examples) in the package documentation.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Python package
 
-[![](https://img.shields.io/badge/PyPI-masquer-3775A9.svg?style=flat&logo=PyPI&logoColor=white)](https://pypi.org/project/masquer/)
+[![PyPI](https://img.shields.io/badge/PyPI-masquer-3775A9.svg?style=flat&logo=PyPI&logoColor=white)](https://pypi.org/project/masquer/)
 
 ### Installation
 
@@ -190,12 +190,12 @@ To get the header-data with randomly selected user-agent and/or referer data, pa
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Git repository
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
 
 Clone the `masquer` repo for the full source code, including the FastAPI app used to host the [API](#api) introduced above. 
 
@@ -262,7 +262,7 @@ Then follow the instructions FastAPI provides in the terminal.
 To view the API's interactive documentation, run the app and navigate to `http://127.0.0.1:8000/docs` or `http://127.0.0.1:8000/redoc`.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Docker image
@@ -286,5 +286,5 @@ $ docker run -d --name masquer -p 8000:8000 essteer/masquer
 Then interact as per the [API instructions](#api) above.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,7 +80,7 @@ If the app launches successfully, visit the documentation link provided and test
 If the tests work from the documentation, make a `curl` request from a separate terminal window:
 
 ```console
-$ curl -X GET 'http://127.0.0.1:8000/masq?ua=true&rf=true' -H 'accept: application/json'
+$ curl -X GET 'http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true' -H 'accept: application/json'
 ```
 
 If the expected response is received, proceed to the Docker image tests.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,8 @@ Asset updates are performed on a regular basis to keep the user-agent and refere
 
 A typical workflow up to the testing stage is outlined in this section.
 
+### Create feature branch 
+
 Activate the virtual environment then create and checkout a new branch such as `asset-update`.
 
 ```console
@@ -50,7 +52,7 @@ For an asset update, follow the instructions detailed under the [`Asset updates`
 If the process is successful and no issues arose, continue to the testing stage.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Test
@@ -67,7 +69,7 @@ Ensure all tests are passing before proceeding further.
 
 ### API tests
 
-<a href="https://github.com/tiangolo/fastapi"><img src="https://img.shields.io/badge/FastAPI-009688?style=flat&logo=FastAPI&labelColor=555&logoColor=white"></a>
+[![FastAPI](https://img.shields.io/badge/FastAPI-masquer-009688?style=flat&logo=FastAPI&logoColor=white)](https://masquer.fly.dev/docs)
 
 Once the unit tests have passed, run the FastAPI app from the project root directory in development mode:
 
@@ -87,7 +89,7 @@ If the expected response is received, proceed to the Docker image tests.
 
 ### Docker image tests
 
-<a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/badge/masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white"></a>
+[![Docker](https://img.shields.io/badge/Docker-masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white)](https://hub.docker.com/r/essteer/masquer)
 
 Follow the steps detailed in [`docker.md`](https://github.com/essteer/masquer/blob/main/docs/docker.md) to build and test a Docker image locally.
 
@@ -96,7 +98,7 @@ Once the image and container are confirmed as running successfully, repeat the A
 If each of the steps indicated above is successful, deployment can proceed to the next stage.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Version
@@ -113,15 +115,13 @@ New: 1.2.2
 
 This will automatically update the version number in `src/masquer/__about__.py`, which is where the version information in `pyproject.toml` is read from for the main `masquer` program, and in `src/api/main.py` for the API.
 
-Manually update the version number in the PyPI icon at the top of [`README.md`](https://github.com/essteer/masquer/blob/main/README.md) to match the new version number.
-
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Format
 
- <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Add and commit the version changes to git. 
 
@@ -134,12 +134,12 @@ See the [`Formatting`](https://github.com/essteer/masquer/blob/main/docs/develop
 Push to GitHub.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Merge to `main`
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
 
 If the package build was successful, open a PR on GitHub to merge the updated package into `main` branch. 
 
@@ -148,13 +148,13 @@ GitHub workflows are in place to do a final format and test whenever a commit or
 See the [`GitHub Actions`](https://github.com/essteer/masquer/blob/main/docs/development.md#github-actions) section of [`development.md`](https://github.com/essteer/masquer/blob/main/docs/development.md) for more details. 
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Release and build Docker image
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
-<a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/badge/masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white"></a>
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![Docker](https://img.shields.io/badge/Docker-masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white)](https://hub.docker.com/r/essteer/masquer)
 
 Assuming that the PR passed the GitHub Actions and the merge completed successfully, from the [main repo page](https://github.com/essteer/masquer) on GitHub click on the `Releases` heading then `Draft a new release`.
 
@@ -169,7 +169,7 @@ The `docker.yaml` GitHub workflow will then build a Docker image of the new vers
 Follow the instructions in [`docker.md`](https://github.com/essteer/masquer/blob/main/docs/docker.md) to pull and test that the image is working as expected.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Build distribution
@@ -187,12 +187,12 @@ dist/masquer-1.2.2-py3-none-any.whl
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Publish to PyPI
 
-<a href="https://pypi.org/project/masquer/"><img src="https://img.shields.io/badge/PyPI-3775A9.svg?style=flat&labelColor=555&logo=PyPI&logoColor=white"></a>
+[![PyPI](https://img.shields.io/pypi/v/masquer?style=flat&logo=PyPI&logoColor=white&label=PyPI&labelColor=555&color=3776AB)](https://pypi.org/project/masquer/)
 
 After a successful build the package is ready to publish on PyPI:
 
@@ -209,13 +209,12 @@ https://pypi.org/project/masquer/1.2.2/
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Deploy to production
 
-<a href="https://masquer.fly.dev/docs"><img src="https://img.shields.io/badge/Fly.io-24175B.svg?style=flat&labelColor=555&logo=flydotio&logoColor=white"></a>
-
+[![Fly.io](https://img.shields.io/badge/Fly.io-masquer-24175B.svg?style=flat&labelColor=555&logo=flydotio&logoColor=white)](https://masquer.fly.dev/docs)
 
 From the project root directory, run the following command to deploy to production:
 
@@ -226,5 +225,5 @@ $ fly deploy
 Visit the deployment at the link as prompted and test it via the API docs.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,7 +18,7 @@ See also the main [`README.md`](https://github.com/essteer/masquer/blob/main/REA
 
 ## Git repository
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
 
 Clone the `masquer` repo for the full source code:
 
@@ -51,7 +51,7 @@ The directory structure of the repo is as follows:
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Asset updates
@@ -75,12 +75,12 @@ In case of issues updating the assets, ensure all dependencies are installed and
 If using custom JSON data, the `update_assets()` function inside `update.py` can still be used to sync changes with the `assets.py` file inside the `masquer` package.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Docker
 
-<a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/badge/Docker-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white"></a>
+[![Docker](https://img.shields.io/badge/Docker-masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white)](https://hub.docker.com/r/essteer/masquer)
 
 In production `masquer` is deployed from a Docker image that is also called `masquer` and is registered here on Docker hub: [`https://hub.docker.com/r/essteer/masquer`](https://hub.docker.com/r/essteer/masquer).
 
@@ -98,12 +98,12 @@ During development &mdash; especially in the event of changes to the package dir
 A `docker.yaml` workflow is in place to build and publish a Docker image when a new release is made on the `main` branch &mdash; see the notes in [`deployment.md`](https://github.com/essteer/masquer/blob/main/docs/deployment.md) and [`docker.md`](https://github.com/essteer/masquer/blob/main/docs/docker.md) for more details.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Formatting
 
- <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Python files in `masquer` are formatted using Ruff.
 
@@ -116,12 +116,12 @@ A pre-commit hook is configured in `.pre-commit-config.yaml` to check and format
 A GitHub action is configured in `.github/workflows/ruff.yaml` to run Ruff checks for any push or pull request to the `main` branch.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## GitHub Actions
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
 
 GitHub actions are configured in `.github/workflows` and are in place for all pushes and pull requests for the `main` branch:
 
@@ -131,7 +131,7 @@ GitHub actions are configured in `.github/workflows` and are in place for all pu
 A `docker.yaml` workflow is in place to build a new Docker image and publish it to Docker Hub whenever a new release is made on the `main` branch &mdash; see the [`deployment.md`](https://github.com/essteer/masquer/blob/main/docs/deployment.md) notes for more details.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Logs
@@ -179,7 +179,7 @@ The following files are set up to record log messages:
 | `src/masquer` | `app.py` | |
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Tests
@@ -215,5 +215,5 @@ A GitHub action is configured in `.github/workflows/test.yaml` to run the unit t
 The tests are run on a matrix basis for Linux (Ubuntu), macOS and Windows on Python versions from `3.9` to `3.12` (inclusive).
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -102,9 +102,9 @@ The first several characters of the container's `sha256` are displayed under the
 With the container running, test a few API calls with different arguments and verify that the expected output is received, for example:
 
 ```console
-$ curl -X GET 'http://127.0.0.1:8000/masq' -H 'accept: application/json'
-$ curl -X GET 'http://127.0.0.1:8000/masq?ua=true&rf=true&hd=true' -H 'accept: application/json'
-$ curl -X GET 'http://127.0.0.1:8000/masq?ua=true&rf=true&hd=false' -H 'accept: application/json'
+$ curl -X GET 'http://127.0.0.1:8000/api/v1/masq' -H 'accept: application/json'
+$ curl -X GET 'http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true&hd=true' -H 'accept: application/json'
+$ curl -X GET 'http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true&hd=false' -H 'accept: application/json'
 ```
 
 <h3 align="center">

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,13 @@
 <h1 align="center" id="title">Masquer &mdash; Docker notes</h1>
 
 <p align="center">
+  <a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/badge/Image-masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white"></a>
+  <a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/docker/pulls/essteer/masquer?style=flat&logo=Docker&logoColor=white&label=Pulls&color=2496ED"></a>
+  <a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/docker/image-size/essteer/masquer?style=flat&logo=Docker&logoColor=white&label=Size&color=2496ED"></a>
+  <a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/docker/v/essteer/masquer?style=flat&logo=Docker&logoColor=white&label=Version&color=2496ED"></a>
+</p>
+
+<p align="center">
   Notes for use in creating, testing, and publishing the <code>masquer</code> Docker image.
 </p>
 
@@ -19,7 +26,7 @@ See also the main [`README.md`](https://github.com/essteer/masquer/blob/main/REA
 
 ## Overview
 
-<a href="https://hub.docker.com/r/essteer/masquer"><img src="https://img.shields.io/badge/Docker-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white"></a>
+[![Docker](https://img.shields.io/badge/Docker-masquer-2496ED.svg?flat&logo=Docker&labelColor=555&logoColor=white)](https://hub.docker.com/r/essteer/masquer)
 
 In production `masquer` is deployed from a Docker image that is also called `masquer` and is registered here on Docker hub: [`https://hub.docker.com/r/essteer/masquer`](https://hub.docker.com/r/essteer/masquer).
 
@@ -28,9 +35,8 @@ The files used to configure the Docker image are both in the project root direct
 - `Dockerfile`: specifies the steps and commands to execute in the Docker image build process, as well as the top-level directory to include in the image &mdash; in this case, that is the `src` directory
 - `.dockerignore`: specifies files and directories to exclude from the Docker image build
 
-
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## Local development
@@ -65,7 +71,7 @@ If the build is successful, a container can then be run using the image to test 
 Note the first three characters of the image's `sha256` for subsequent use &mdash; in this case `1c3`.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ### Test container
@@ -92,12 +98,12 @@ CONTAINER ID   IMAGE     COMMAND                  CREATED          STATUS       
 The first several characters of the container's `sha256` are displayed under the `CONTAINER ID` column, as are the first three characters of the image's `sha256`.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ### Test API on container
 
-<a href="https://github.com/tiangolo/fastapi"><img src="https://img.shields.io/badge/FastAPI-009688?style=flat&logo=FastAPI&labelColor=555&logoColor=white"></a>
+[![FastAPI](https://img.shields.io/badge/FastAPI-masquer-009688?style=flat&logo=FastAPI&logoColor=white)](https://masquer.fly.dev/docs)
 
 With the container running, test a few API calls with different arguments and verify that the expected output is received, for example:
 
@@ -108,7 +114,7 @@ $ curl -X GET 'http://127.0.0.1:8000/masq?ua=true&rf=true&hd=false' -H 'accept: 
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ### Check logs on container
@@ -122,7 +128,6 @@ $ docker exec -it 392 sh  # 'sh' runs the basic shell
 ```
 
 If successful, the terminal prompt should now display the location on the container (above, `/usr/src/app/src`).
-
 
 Logs should be created on the container at `/usr/src/app/logs/app.log` &mdash; if they are not present then first make sure the path stated here is up to date with the path in the `Dockerfile`.
 
@@ -144,7 +149,7 @@ $
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ### Clean up
@@ -168,19 +173,19 @@ Deleted: sha256:1c3642fd9d54d5870f1ed9dfdaf75d208bee648d15ba87c6de05ja4c5c069512
 ```
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>
 
 ## GitHub Action
 
-[![](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
+[![GitHub](https://img.shields.io/badge/GitHub-masquer-181717.svg?flat&logo=GitHub&logoColor=white)](https://github.com/essteer/masquer)
 
 A `docker.yaml` workflow is in place to build a new Docker image and publish it to Docker Hub whenever a new release is made on the `main` branch.
 
-The image will be published as the latest image version listed at [`https://hub.docker.com/r/essteer/masquer`](https://hub.docker.com/r/essteer/masquer). 
+The image will be published as the latest image version listed at [`https://hub.docker.com/r/essteer/masquer`](https://hub.docker.com/r/essteer/masquer).
 
 For this reason, the image must be tested locally via the steps provided in this document before a new release is made to ensure that it works correctly.
 
 <h3 align="center">
-  <a href="#"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
+  <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>
 </h3>

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -27,13 +27,13 @@ The code examples below illustrate methods for making API calls in different lan
 ### cURL
 
 ```console
-$ curl -X GET 'https://masquer.fly.dev/masq?ua=true&rf=false&hd=false' -H 'accept: application/json'
+$ curl -X GET 'https://masquer.fly.dev/api/v1/masq?ua=true&rf=false&hd=false' -H 'accept: application/json'
 ```
 
 ### JavaScript (using `fetch`)
 
 ```javascript
-fetch('https://masquer.fly.dev/masq?ua=true&rf=false&hd=false')
+fetch('https://masquer.fly.dev/api/v1/masq?ua=true&rf=false&hd=false')
   .then(response => response.json())
   .then(data => console.log(data))
 ```
@@ -42,7 +42,7 @@ fetch('https://masquer.fly.dev/masq?ua=true&rf=false&hd=false')
 
 ```python
 import requests
-response = requests.get("https://masquer.fly.dev/masq", params={"ua": True, "rf": False, "hd": False})
+response = requests.get("https://masquer.fly.dev/api/v1/masq", params={"ua": True, "rf": False, "hd": False})
 print(response.json())
 ```
 """

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -10,7 +10,8 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.get("/masq")
+@router.get("/masq")  # maintain for backwards compatibility
+@router.get("/api/v1/masq")
 def get_masq(
     ua: Union[bool, None] = True,
     rf: Union[bool, None] = False,

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -11,14 +11,29 @@ router = APIRouter()
 
 
 @router.get("/masq")  # maintain for backwards compatibility
-@router.get("/api/v1/masq")
-def get_masq(
+@router.get("/api/v0/masq")
+def get_masq_v0(
     ua: Union[bool, None] = True,
     rf: Union[bool, None] = False,
     hd: Union[bool, None] = False,
 ):
     logger.info(f"Request: [{ua=} {rf=} {hd=}]")
     response = masq(ua, rf, hd)
+    logger.info(f"Response: [{response}]")
+
+    return JSONResponse(content=response)
+
+@router.get("/api/v1/masq")
+def get_masq(
+    ua: Union[bool, None] = True,
+    rf: Union[bool, None] = False,
+    hd: Union[bool, None] = False,
+    count: Union[int, None] = 1,
+):
+    logger.info(f"Request: [{ua=} {rf=} {hd=}]")
+    if count >= 250: count = 250
+    if count <= 0: count = 1
+    response = [masq(ua, rf, hd) for _ in range(count)]
     logger.info(f"Response: [{response}]")
 
     return JSONResponse(content=response)

--- a/src/masquer/utils/response.py
+++ b/src/masquer/utils/response.py
@@ -27,7 +27,7 @@ def get_response(
     response_data = dict()
 
     if header_requested:
-        response_data = HEADER_DATA
+        response_data = dict(HEADER_DATA)
 
     if referer_requested:
         referer = select_data(REFERERS, REFERER_WEIGHTS)


### PR DESCRIPTION
## Enhancements
* [`src/api/routes.py`](diffhunk://#diff-2b14c7a998aaa1ab1d7edf7c92ea3a82f9739c3e2d0ee69fd33b2aa0e71f68beR18-R25): Added a `count` parameter to the `get_masq` function to allow multiple responses. The function now returns a list of responses if `count` is greater than 1.

## Fixes
* [`src/masquer/utils/response.py`](diffhunk://#diff-8ec5b523a660392d0a62b5e47cfaf0f33d907b44b2f9bfa68d69049a8c0abd82L30-R30): Modified the assignment of `response_data` to create a new dictionary from `HEADER_DATA` to avoid unintended side effects.