### PR TITLE
feat: Add request templates for dev and prod use

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ curl -X GET 'https://masquer.fly.dev/api/v1/masq?ua=true&rf=true' -H 'accept: 
 
 The optional `count` parameter specifies the number of objects to return in the response. The default value is `1`.
 
-Refer to the [API docs](`https://masquer.fly.dev/docs`) for other examples, or see [more details below](#examples) in the package documentation.
+Refer to the [API docs](`https://masquer.fly.dev/docs`) for other examples, or see [more details below](#examples) in the package documentation. The `tests/requests/` directory also contains HTTP request examples for use in development and production.
 
 <h3 align="center">
   <a href="#title"><img src="https://img.shields.io/badge/▲%20Top%20▲-0466c8.svg?style=flat"></a>

--- a/tests/requests/dev/default.posting.yaml
+++ b/tests/requests/dev/default.posting.yaml
@@ -1,0 +1,3 @@
+name: default
+description: Default GET request with no parameters, returns a random useragent.
+url: http://127.0.0.1:8000/api/v1/masq

--- a/tests/requests/dev/hd.posting.yaml
+++ b/tests/requests/dev/hd.posting.yaml
@@ -1,0 +1,3 @@
+name: hd
+description: Returns header data with random useragent and fixed referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=false&hd=true

--- a/tests/requests/dev/rf-hd.posting.yaml
+++ b/tests/requests/dev/rf-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: rf-hd
+description: Returns header data with fixed useragent and random referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=false&rf=true&hd=true

--- a/tests/requests/dev/rf.posting.yaml
+++ b/tests/requests/dev/rf.posting.yaml
@@ -1,0 +1,3 @@
+name: rf
+description: Returns a random referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=false&rf=true

--- a/tests/requests/dev/ua-hd.posting.yaml
+++ b/tests/requests/dev/ua-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-hd
+description: Returns header data with random useragent and fixed referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=true&hd=true

--- a/tests/requests/dev/ua-rf-hd-count.posting.yaml
+++ b/tests/requests/dev/ua-rf-hd-count.posting.yaml
@@ -1,0 +1,4 @@
+name: ua-rf-hd-count
+description: Returns multiple sets of header data with random useragent and random
+  referer, as specified by the count param.
+url: http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true&hd=true&count=3

--- a/tests/requests/dev/ua-rf-hd.posting.yaml
+++ b/tests/requests/dev/ua-rf-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-rf-hd
+description: Returns header data with random useragent and random referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true&hd=true

--- a/tests/requests/dev/ua-rf.posting.yaml
+++ b/tests/requests/dev/ua-rf.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-rf
+description: Returns random useragent and random referer.
+url: http://127.0.0.1:8000/api/v1/masq?ua=true&rf=true

--- a/tests/requests/dev/ua.posting.yaml
+++ b/tests/requests/dev/ua.posting.yaml
@@ -1,0 +1,3 @@
+name: ua
+description: Returns a random useragent, equivalent to the default with no params.
+url: http://127.0.0.1:8000/api/v1/masq?ua=true

--- a/tests/requests/prod/default.posting.yaml
+++ b/tests/requests/prod/default.posting.yaml
@@ -1,0 +1,3 @@
+name: default
+description: Default GET request with no parameters, returns a random useragent.
+url: https://masquer.fly.dev/api/v1/masq

--- a/tests/requests/prod/hd.posting.yaml
+++ b/tests/requests/prod/hd.posting.yaml
@@ -1,0 +1,3 @@
+name: hd
+description: Returns header data with random useragent and fixed referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=false&hd=true

--- a/tests/requests/prod/rf-hd.posting.yaml
+++ b/tests/requests/prod/rf-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: rf-hd
+description: Returns header data with fixed useragent and random referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=false&rf=true&hd=true

--- a/tests/requests/prod/rf.posting.yaml
+++ b/tests/requests/prod/rf.posting.yaml
@@ -1,0 +1,3 @@
+name: rf
+description: Returns a random referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=false&rf=true

--- a/tests/requests/prod/ua-hd.posting.yaml
+++ b/tests/requests/prod/ua-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-hd
+description: Returns header data with random useragent and fixed referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=true&hd=true

--- a/tests/requests/prod/ua-rf-hd-count.posting.yaml
+++ b/tests/requests/prod/ua-rf-hd-count.posting.yaml
@@ -1,0 +1,4 @@
+name: ua-rf-hd-count
+description: Returns multiple sets of header data with random useragent and random
+  referer, as specified by the count param.
+url: https://masquer.fly.dev/api/v1/masq?ua=true&rf=true&hd=true&count=3

--- a/tests/requests/prod/ua-rf-hd.posting.yaml
+++ b/tests/requests/prod/ua-rf-hd.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-rf-hd
+description: Returns header data with random useragent and random referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=true&rf=true&hd=true

--- a/tests/requests/prod/ua-rf.posting.yaml
+++ b/tests/requests/prod/ua-rf.posting.yaml
@@ -1,0 +1,3 @@
+name: ua-rf
+description: Returns random useragent and random referer.
+url: https://masquer.fly.dev/api/v1/masq?ua=true&rf=true

--- a/tests/requests/prod/ua.posting.yaml
+++ b/tests/requests/prod/ua.posting.yaml
@@ -1,0 +1,3 @@
+name: ua
+description: Returns a random useragent, equivalent to the default with no params.
+url: https://masquer.fly.dev/api/v1/masq?ua=true


### PR DESCRIPTION
Adds example `GET` requests for use in dev and prod. Dev templates point to `localhost` endpoints, prod templates point to endpoints at `http://masquer.fly.dev/api/v1/`.